### PR TITLE
only get single collection, and add trailing slash

### DIFF
--- a/ndasynapse/nda.py
+++ b/ndasynapse/nda.py
@@ -97,11 +97,9 @@ def get_samples(auth, guid):
 def get_submissions(auth, collectionid, users_own_submissions=False):
     """Use the NDA api to get the `genomics_sample03` records for a GUID."""
 
-    if isinstance(collectionid, (list,)):
-        collectionid = ",".join(collectionid)
-
-    r = requests.get("https://nda.nih.gov/api/submission",
-                     params={'usersOwnSubmissions': users_own_submissions},
+    r = requests.get("https://nda.nih.gov/api/submission/",
+                     params={'usersOwnSubmissions': users_own_submissions,
+                             'collectionId': collectionid},
                      auth=auth, headers={'Accept': 'application/json'})
 
     logger.debug("Request %s for collection %s" % (r.url, collectionid))


### PR DESCRIPTION
Fixes bug identified by @cw-dvr8 and debugged by David at NDA that API endpoint for submission root requires a trailing slash. Fixed in the client side, will be addressed server side as well.