### PR TITLE
Fix deprecated version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(name='ndasynapse',
                         'boto3>=1.4.2',
                         'boto>=2.46.1',
                         'requests>=2.18.1',
-                        'deprecated>=1.2.4'],
+                        'deprecated==1.2.4'],
       scripts=['bin/nda_to_synapse_manifest.py', 'bin/manifest_to_synapse.py', 'bin/query-nda'],
       zip_safe=False)


### PR DESCRIPTION
The Synapse client uses `deprecated==1.2.4`, so fall back to that one.